### PR TITLE
Set compile options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ hgvs
 
 `gnife [type] [command] --help` to display detailed usage of each command.
 
+## JVM Options
+
+To pass extra arguments to the JVM, set the `GNIFE_JVM_OPTS` environment
+variable.
+
+```sh
+export GNIFE_JVM_OPTS="-XX:TieredStopAtLevel=1 -Xmx4g"
+```
+
 ## Test
 
 To run tests,

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {clj-hgvs/clj-hgvs {:mvn/version "0.4.7"}
         clj-sub-command/clj-sub-command {:mvn/version "0.6.0"}
         cljam/cljam {:mvn/version "0.8.4"}
-        org.clojure/clojure {:mvn/version "1.11.1"}
+        org.clojure/clojure {:mvn/version "1.11.3"}
         org.clojure/tools.cli {:mvn/version "1.1.230"}
         varity/varity {:mvn/version "0.11.0"}}
 
@@ -22,5 +22,5 @@
 
            :build
            {:extra-deps {io.github.clojure/tools.build
-                         {:git/tag "v0.9.6" :git/sha "8e78bcc"}}
+                         {:git/tag "v0.10.0" :git/sha "3a2c484"}}
             :ns-default build}}}


### PR DESCRIPTION
I set `elide-meta` and `direct-linking` to compile options to reduce startup time and binary size a little bit.

I updated dependencies and added descriptions to `README.md` as well.