### PR TITLE
Update URLs of the remote test resources

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,7 @@
  :aliases {:test
            {:extra-paths ["test"]
             :extra-deps {io.github.totakke/cavia
-                         {:git/tag "v0.7.0_1" :git/sha "9dd80e7"}
+                         {:git/tag "v0.7.2" :git/sha "0788cb4"}
                          io.github.cognitect-labs/test-runner
                          {:git/tag "v0.5.1" :git/sha "dfb30dd"}
                          nubank/matcher-combinators {:mvn/version "3.9.1"}}

--- a/test/gnife/test/resource.clj
+++ b/test/gnife/test/resource.clj
@@ -3,10 +3,10 @@
 
 (cavia/defprofile cavia-prof
   {:resources [{:id "hg38.2bit"
-                :url "https://test.chrov.is/data/varity/hg38.2bit"
+                :url "https://test-resources.chrov.is/data/varity/hg38.2bit"
                 :sha1 "6fb20ba4de0b49247b78e08c2394d0c4f8594148"}
                {:id "hg38-refGene.txt.gz"
-                :url "https://test.chrov.is/data/varity/hg38-refGene.txt.gz"
+                :url "https://test-resources.chrov.is/data/varity/hg38-refGene.txt.gz"
                 :sha1 "941d514e57f4e842743f5c9269a0279906a072a0"}]})
 
 (defn prepare-cavia!


### PR DESCRIPTION
I have updated URLs of the remote test resources from `test.chrov.is` to `test-resources.chrov.is`.

The slow test has been confirmed:

```sh
rm -r .cavia
clojure -X:test:slow-test
```